### PR TITLE
Add blog page and internal links

### DIFF
--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -1,8 +1,9 @@
+import { Link } from "gatsby";
 import styled from "styled-components";
 
 import { color, spacing } from "../utils";
 
-export default styled.button`
+export default styled(Link).attrs({ activeClassName: "active" })`
   width: 100%;
   margin: 0 ${spacing(3)};
   border: 1px solid ${color("primary")};
@@ -11,8 +12,16 @@ export default styled.button`
   background-color: ${color("background")};
   transition: all 0.1s;
   cursor: pointer;
+  text-align: center;
+  text-decoration: none !important;
 
   &:hover {
+    color: ${color("content")};
+    background-color: ${color("secondary")} !important;
+    border: 1px solid ${color("secondary")};
+  }
+
+  &.active {
     color: ${color("content")};
     background-color: ${color("primary")};
   }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { Turn as Hamburger } from "hamburger-react";
 
-import Button from "./button";
+import Link from "./link";
 import { useGitHubUser } from "../data";
 import { color, spacing } from "../utils";
 
@@ -37,8 +37,8 @@ const Navbar = ({ className }: Props) => {
       </Row>
       {isOpen && (
         <Row mg={3}>
-          <Button>About</Button>
-          <Button>Blog</Button>
+          <Link to="/">About</Link>
+          <Link to="/blog">Blog</Link>
         </Row>
       )}
     </nav>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -11,7 +11,7 @@ import {
   FaInstagram,
 } from "react-icons/fa";
 
-import Button from "./button";
+import Link from "./link";
 import { useGitHubUser } from "../data";
 import { color, spacing } from "../utils";
 
@@ -42,7 +42,7 @@ const ContactDetail = styled.div`
   }
 `;
 
-const Link = styled.a`
+const ExternalLink = styled.a`
   display: flex;
   align-items: center;
   color: ${color("primary")};
@@ -63,8 +63,8 @@ const Sidebar = ({ className }: Props) => {
       <Avatar src={my.avatarUrl} />
       <h1>{my.name}</h1>
       <Row>
-        <Button>About</Button>
-        <Button>Blog</Button>
+        <Link to="/">About</Link>
+        <Link to="/blog">Blog</Link>
       </Row>
       <CenterAlignedText>{my.bio}</CenterAlignedText>
       <div>
@@ -78,25 +78,25 @@ const Sidebar = ({ className }: Props) => {
         </ContactDetail>
         <ContactDetail>
           <FaRegEnvelope size="1.2rem" title="Email address" />
-          <Link href={`mailto:${my.email}`}>{my.email}</Link>
+          <ExternalLink href={`mailto:${my.email}`}>{my.email}</ExternalLink>
         </ContactDetail>
       </div>
       <Row>
-        <Link href={my.url}>
+        <ExternalLink href={my.url}>
           <FaGithub size="1.2rem" title="GitHub" />
-        </Link>
-        <Link href="https://www.linkedin.com/in/lawrencejb/">
+        </ExternalLink>
+        <ExternalLink href="https://www.linkedin.com/in/lawrencejb/">
           <FaLinkedin size="1.2rem" title="LinkedIn" />
-        </Link>
-        <Link href="https://stackoverflow.com/users/13417313">
+        </ExternalLink>
+        <ExternalLink href="https://stackoverflow.com/users/13417313">
           <FaStackOverflow size="1.2rem" title="Stack Overflow" />
-        </Link>
-        <Link href="https://twitter.com/lawrencejberry">
+        </ExternalLink>
+        <ExternalLink href="https://twitter.com/lawrencejberry">
           <FaTwitter size="1.2rem" title="Twitter" />
-        </Link>
-        <Link href="https://www.instagram.com/lawrencejberry">
+        </ExternalLink>
+        <ExternalLink href="https://www.instagram.com/lawrencejberry">
           <FaInstagram size="1.2rem" title="Instagram" />
-        </Link>
+        </ExternalLink>
       </Row>
     </div>
   );

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+import { Layout } from "../components";
+
+const BlogPage = () => {
+  return <Layout>This is the blog page.</Layout>;
+};
+
+export default BlogPage;


### PR DESCRIPTION
Closes #1 

* Adds a blog page with some placeholder text and turns the side bar and nav bar buttons into internal Gatsby links with active styling.